### PR TITLE
clear all env vars except PATH when running cargo

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,6 +41,7 @@ impl TargetDep {
 
         let cargo_bin = build_env_var("CARGO");
         let mut cmd = Command::new(cargo_bin);
+        cmd.env_clear().env("PATH", env::var_os("PATH").unwrap());
 
         cmd.arg("build");
 


### PR DESCRIPTION
This is necessary to avoid confusing rustc when running `cargo-tarpaulin` on Mac and Windows using `--engine llvm`.