### PR TITLE
Revert "clear all env vars except PATH when running cargo"

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,7 +41,6 @@ impl TargetDep {
 
         let cargo_bin = build_env_var("CARGO");
         let mut cmd = Command::new(cargo_bin);
-        cmd.env_clear().env("PATH", env::var_os("PATH").unwrap());
 
         cmd.arg("build");
 


### PR DESCRIPTION
This reverts commit 90051482c4fc1d6ca33a866fd2edfa073c031079.

Turns out it was more trouble than it was worth and broke Windows CI.